### PR TITLE
[Android] Remap the URL before loading in WebView

### DIFF
--- a/src/android/AppScopePlugin.java
+++ b/src/android/AppScopePlugin.java
@@ -51,7 +51,7 @@ public class AppScopePlugin extends CordovaPlugin {
 
         final Uri remapped = this.remapUri(intentUri);
 
-        if (remapped !== null) {
+        if (remapped != null) {
             this.webView.loadUrlIntoView(remapped.toString(), false);
         }
     }


### PR DESCRIPTION
This matches the implementation on iOS and means that an incoming URL like `https://app.scope/#/foo` will always cause a `file:///` URL to be loaded in the WebView.

This is useful because then we are able to rely on things like the existence of a `file:///` URL to indicate that we need to use hash-based routing instead of pushState fragments.