### PR TITLE
Change the way the remapped URI is loaded into the webview

### DIFF
--- a/src/android/AppScopePlugin.java
+++ b/src/android/AppScopePlugin.java
@@ -52,7 +52,7 @@ public class AppScopePlugin extends CordovaPlugin {
         final Uri remapped = this.remapUri(intentUri);
 
         if (remapped != null) {
-            this.webView.loadUrlIntoView(remapped.toString(), false);
+            this.webView.getEngine().loadUrl(remapped.toString(), false);
         }
     }
 


### PR DESCRIPTION
This avoids the `CordovaWebView: TIMEOUT!` error