### PR TITLE
Fix ElementTree imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
       "name": "cordova-ios",
       "version": ">= 4.5.0"
     }
-  ]
+  ],
+  "dependencies": {
+    "elementtree": "^0.1.7"
+  }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,6 +36,8 @@
         <param name="ios-package" value="CDVAppScopePlugin" />
         <param name="onload" value="true" />
       </feature>
+
+      <preference name="SwiftVersion" value="4.0" />
     </config-file>
 
     <header-file src="src/ios/CDVAppDelegate+AppScope.h" />

--- a/src/prepare_hook.js
+++ b/src/prepare_hook.js
@@ -17,7 +17,7 @@
 
 const configPatches = {
     android: function(context, scope) {
-        const et = context.requireCordovaModule('elementtree');
+        const et = require('elementtree');
 
         let intentFilter = et.Element('intent-filter');
         intentFilter.set('android:label', '@string/launcher_name');
@@ -42,7 +42,7 @@ const configPatches = {
     },
 
     ios: function(context, scope) {
-        const et = context.requireCordovaModule('elementtree');
+        const et = require('elementtree');
 
         let array = et.Element('array');
 


### PR DESCRIPTION
`elementtree` is not a built-in Cordova module, so best practice now is to explicitly depend on it in the plugin.