### PR TITLE
[iOS] Compatibility with UISceneDelegate & cordova-ios 8.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test-ios:
+    name: "iOS Tests"
+    runs-on: macos-26
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+
+      - name: Run iOS Unit Tests
+        run: |
+          xcodebuild test -quiet \
+            -project AppScopePluginTests.xcodeproj \
+            -scheme AppScopePluginTests \
+            -testPlan UnitTests \
+            -destination "platform=iOS Simulator,name=iPhone 17e"
+        working-directory: ./tests/ios

--- a/plugin.xml
+++ b/plugin.xml
@@ -41,7 +41,7 @@
 
     <header-file src="src/ios/CDVAppDelegate+AppScope.h" />
     <source-file src="src/ios/CDVAppDelegate+AppScope.m" />
-    <source-file src="src/ios/CDVAppScopePlugin.swift" />
+    <source-file src="src/ios/AppScopePlugin.swift" />
   </platform>
 
 

--- a/src/ios/AppScopePlugin.swift
+++ b/src/ios/AppScopePlugin.swift
@@ -18,22 +18,23 @@
 import Cordova
 #endif
 
-@objc class CDVAppScopePlugin : CDVPlugin {
+@objc(CDVAppScopePlugin)
+class AppScopePlugin : CDVPlugin {
     override func pluginInitialize() {
         NotificationCenter.default.addObserver(self,
-                selector: #selector(CDVAppScopePlugin._didFinishLaunchingWithOptions(_:)),
+                selector: #selector(AppScopePlugin._didFinishLaunchingWithOptions(_:)),
                 name: UIApplication.didFinishLaunchingNotification,
                 object: nil);
 
 
         NotificationCenter.default.addObserver(self,
-                selector: #selector(CDVAppScopePlugin._handleOpenURL(_:)),
+                selector: #selector(AppScopePlugin._handleOpenURL(_:)),
                 name: NSNotification.Name.CDVPluginHandleOpenURL,
                 object: nil);
 
 
         NotificationCenter.default.addObserver(self,
-                selector: #selector(CDVAppScopePlugin._handleContinueUserActivity(_:)),
+                selector: #selector(AppScopePlugin._handleContinueUserActivity(_:)),
                 name: NSNotification.Name("CDVPluginContinueUserActivityNotification"),
                 object: nil);
     }

--- a/src/ios/CDVAppDelegate+AppScope.h
+++ b/src/ios/CDVAppDelegate+AppScope.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "Cordova/CDVAppDelegate.h"
+#import "Cordova/Cordova.h"
 
 @interface CDVAppDelegate (appScope)
 

--- a/src/ios/CDVAppDelegate+AppScope.m
+++ b/src/ios/CDVAppDelegate+AppScope.m
@@ -21,9 +21,7 @@
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler;
 {
     if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
-        NSLog(@"APPSCOPE-PLUGIN: continueUserActivity with URL: %@", userActivity.webpageURL);
-
-        [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:userActivity.webpageURL]];
+        [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:@"CDVPluginContinueUserActivityNotification" object:userActivity]];
 
         return YES;
     }

--- a/src/ios/CDVAppScopePlugin.swift
+++ b/src/ios/CDVAppScopePlugin.swift
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-@objc(CDVAppScopePlugin)
-class CDVAppScopePlugin : CDVPlugin {
+#if canImport(Cordova)
+import Cordova
+#endif
+
+@objc class CDVAppScopePlugin : CDVPlugin {
     override func pluginInitialize() {
         NotificationCenter.default.addObserver(self,
                 selector: #selector(CDVAppScopePlugin._didFinishLaunchingWithOptions(_:)),
@@ -26,6 +29,12 @@ class CDVAppScopePlugin : CDVPlugin {
         NotificationCenter.default.addObserver(self,
                 selector: #selector(CDVAppScopePlugin._handleOpenURL(_:)),
                 name: NSNotification.Name.CDVPluginHandleOpenURL,
+                object: nil);
+
+
+        NotificationCenter.default.addObserver(self,
+                selector: #selector(CDVAppScopePlugin._handleContinueUserActivity(_:)),
+                name: NSNotification.Name("CDVPluginContinueUserActivityNotification"),
                 object: nil);
     }
 
@@ -65,8 +74,10 @@ class CDVAppScopePlugin : CDVPlugin {
             remapped = "index.html" + remapped;
         }
 
-        let startURL = URL(string: remapped)
-        let startFilePath = self.commandDelegate.path(forResource: startURL?.path)
+        guard let startURL = URL(string: remapped) else {
+            return
+        }
+        let startFilePath: String? = self.commandDelegate.path(forResource: startURL.path)
 
         var appURL = URL(fileURLWithPath: startFilePath!)
 
@@ -79,5 +90,23 @@ class CDVAppScopePlugin : CDVPlugin {
 
         let appReq = URLRequest(url: appURL, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 20.0)
         self.webViewEngine.load(appReq)
+    }
+
+
+
+    @objc internal func _handleContinueUserActivity(_ notification : NSNotification) {
+        guard let activity = notification.object as? NSUserActivity else {
+            return
+        }
+
+        if activity.activityType == NSUserActivityTypeBrowsingWeb {
+            guard let incomingUrl = activity.webpageURL else {
+                return
+            }
+
+            NSLog("APPSCOPE-PLUGIN: continueUserActivity with URL: \(incomingUrl)")
+
+            NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: incomingUrl);
+        }
     }
 }

--- a/tests/ios/.gitignore
+++ b/tests/ios/.gitignore
@@ -1,0 +1,3 @@
+xcuserdata/
+Package.resolved
+App/www

--- a/tests/ios/App/AppDelegate.swift
+++ b/tests/ios/App/AppDelegate.swift
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2026 Darryl Pogue
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import UIKit
+import Cordova
+
+@UIApplicationMain
+class AppDelegate: CDVAppDelegate {
+    override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        if #available(iOS 13.0, *) {
+            // Handled in application:configurationForConnecting:options:
+        } else {
+            let bounds = UIScreen.main.bounds;
+            let window = UIWindow(frame: bounds);
+            window.autoresizesSubviews = true;
+            window.rootViewController = CDVViewController();
+            window.makeKeyAndVisible();
+
+            self.window = window;
+        }
+
+        return true;
+    }
+
+    @available(iOS 13.0, *)
+    override func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        let configuration = UISceneConfiguration(name: "Default Configuration", sessionRole:connectingSceneSession.role)
+        configuration.delegateClass = SceneDelegate.self
+        return configuration
+    }
+}
+
+@available(iOS 13.0, *)
+class SceneDelegate: CDVSceneDelegate {
+    override func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = (scene as? UIWindowScene) else {
+            return
+        }
+
+        let window = UIWindow(windowScene: windowScene)
+        window.autoresizesSubviews = true;
+        window.rootViewController = CDVViewController();
+        window.makeKeyAndVisible();
+
+        self.window = window;
+
+        if let appDelegate = (UIApplication.shared.delegate as? AppDelegate) {
+            appDelegate.window = window;
+        }
+    }
+}

--- a/tests/ios/App/CDVAppDelegate+AppScope.h
+++ b/tests/ios/App/CDVAppDelegate+AppScope.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2018 Ayogo Health Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "Cordova/Cordova.h"
+
+@interface CDVAppDelegate (appScope)
+
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler;
+
+@end

--- a/tests/ios/App/CDVAppDelegate+AppScope.m
+++ b/tests/ios/App/CDVAppDelegate+AppScope.m
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 Ayogo Health Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "CDVAppDelegate+AppScope.h"
+
+@implementation CDVAppDelegate (appScope)
+
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler;
+{
+    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:@"CDVPluginContinueUserActivityNotification" object:userActivity]];
+
+    return [userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb];
+}
+
+@end

--- a/tests/ios/App/Info.plist
+++ b/tests/ios/App/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIImageName</key>
+		<string></string>
+	</dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/tests/ios/App/config.xml
+++ b/tests/ios/App/config.xml
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+Copyright 2026 Darryl Pogue
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<widget id="com.ayogo.cordova.appscope.tests" version="1.0.0" xmlns="http://www.w3.org/ns/widgets">
+    <name>AppScopePluginTests</name>
+    <author email="info@ayogo.com" href="http://www.ayogo.com">Ayogo Health Inc.</author>
+
+    <content src="index.html" />
+
+    <allow-intent href="http://*/*" />
+    <allow-intent href="https://*/*" />
+
+    <preference name="AllowInlineMediaPlayback" value="false" />
+    <preference name="BackupWebStorage" value="cloud" />
+    <preference name="DisallowOverscroll" value="true" />
+    <preference name="EnableViewportScale" value="false" />
+    <preference name="KeyboardDisplayRequiresUserAction" value="true" />
+    <preference name="MediaTypesRequiringUserActionForPlayback" value="none" />
+    <preference name="SuppressesIncrementalRendering" value="false" />
+    <preference name="SuppressesLongPressGesture" value="false" />
+    <preference name="Suppresses3DTouchGesture" value="false" />
+    <preference name="GapBetweenPages" value="0" />
+    <preference name="PageLength" value="0" />
+    <preference name="PaginationBreakingMode" value="page" />
+    <preference name="PaginationMode" value="unpaginated" />
+    <preference name="SwiftVersion" value="5.0" />
+
+    <feature name="CDVWebViewEngine">
+        <param name="ios-package" value="CDVWebViewEngine" />
+    </feature>
+    <feature name="LaunchScreen">
+        <param name="ios-package" value="CDVLaunchScreen" />
+    </feature>
+    <feature name="LocalStorage">
+        <param name="ios-package" value="CDVLocalStorage" />
+    </feature>
+    <feature name="Console">
+        <param name="ios-package" value="CDVLogger" />
+        <param name="onload" value="true" />
+    </feature>
+    <feature name="HandleOpenUrl">
+        <param name="ios-package" value="CDVHandleOpenURL" />
+        <param name="onload" value="true" />
+    </feature>
+    <feature name="IntentAndNavigationFilter">
+        <param name="ios-package" value="CDVIntentAndNavigationFilter" />
+        <param name="onload" value="true" />
+    </feature>
+    <feature name="GestureHandler">
+        <param name="ios-package" value="CDVGestureHandler" />
+        <param name="onload" value="true" />
+    </feature>
+    <feature name="AppScope">
+        <param name="ios-package" value="CDVAppScopePlugin" />
+        <param name="onload" value="true" />
+    </feature>
+</widget>

--- a/tests/ios/AppScopePluginTests.xcodeproj/DeviceTests.xctestplan
+++ b/tests/ios/AppScopePluginTests.xcodeproj/DeviceTests.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "499B7A65-D2B7-4953-8541-6A9A89F54ADE",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "repeatInNewRunnerProcess" : true,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:AppScopePluginTests.xcodeproj",
+      "identifier" : "905131B827F1631300AC00FC",
+      "name" : "AppScopePluginTest"
+    },
+    "testRepetitionMode" : "retryOnFailure"
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:AppScopePluginTests.xcodeproj",
+        "identifier" : "905131D827F1631600AC00FC",
+        "name" : "UITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/tests/ios/AppScopePluginTests.xcodeproj/UnitTests.xctestplan
+++ b/tests/ios/AppScopePluginTests.xcodeproj/UnitTests.xctestplan
@@ -1,0 +1,32 @@
+{
+  "configurations" : [
+    {
+      "id" : "AE69ADA5-1D54-4DAE-AD6A-E00C0A1C9CD0",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : true,
+    "repeatInNewRunnerProcess" : true,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:AppScopePluginTests.xcodeproj",
+      "identifier" : "905131B827F1631300AC00FC",
+      "name" : "AppScopePluginTest"
+    },
+    "testRepetitionMode" : "retryOnFailure"
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:AppScopePluginTests.xcodeproj",
+        "identifier" : "905131CE27F1631600AC00FC",
+        "name" : "Tests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/tests/ios/AppScopePluginTests.xcodeproj/project.pbxproj
+++ b/tests/ios/AppScopePluginTests.xcodeproj/project.pbxproj
@@ -1,0 +1,619 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		905131BD27F1631300AC00FC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905131BC27F1631300AC00FC /* AppDelegate.swift */; };
+		905131EE27F1648A00AC00FC /* Cordova in Frameworks */ = {isa = PBXBuildFile; productRef = 905131ED27F1648A00AC00FC /* Cordova */; };
+		905131F127F1670900AC00FC /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 905131F027F1670900AC00FC /* config.xml */; };
+		905131F827F168FC00AC00FC /* AppScopePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905131F727F168FC00AC00FC /* AppScopePlugin.swift */; };
+		9053AFA62FCFA05100040EA5 /* CDVAppDelegate+AppScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 9053AFA52FCFA05100040EA5 /* CDVAppDelegate+AppScope.m */; };
+		907328F328D04C0C006F6BFA /* www in Resources */ = {isa = PBXBuildFile; fileRef = 907328F228D04C0C006F6BFA /* www */; };
+		90B113092FCFAA55007754D6 /* AppDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B113082FCFAA4F007754D6 /* AppDelegateTests.swift */; };
+		90B1130B2FCFAEED007754D6 /* SceneDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B1130A2FCFAEE9007754D6 /* SceneDelegateTests.swift */; };
+		90D1FCC22FD1F227000192AF /* AppScopePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D1FCC12FD1F223000192AF /* AppScopePluginTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		905131D027F1631600AC00FC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 905131B127F1631300AC00FC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 905131B827F1631300AC00FC;
+			remoteInfo = Tests;
+		};
+		905131DA27F1631600AC00FC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 905131B127F1631300AC00FC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 905131B827F1631300AC00FC;
+			remoteInfo = Tests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		905131B927F1631300AC00FC /* AppScopePluginTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppScopePluginTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		905131BC27F1631300AC00FC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		905131CF27F1631600AC00FC /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		905131D927F1631600AC00FC /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		905131F027F1670900AC00FC /* config.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
+		905131F727F168FC00AC00FC /* AppScopePlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppScopePlugin.swift; path = ../../../src/ios/AppScopePlugin.swift; sourceTree = "<group>"; };
+		9053AFA42FCFA05100040EA5 /* CDVAppDelegate+AppScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CDVAppDelegate+AppScope.h"; sourceTree = "<group>"; };
+		9053AFA52FCFA05100040EA5 /* CDVAppDelegate+AppScope.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CDVAppDelegate+AppScope.m"; sourceTree = "<group>"; };
+		9056A938285BDDC00086CDF8 /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = AppScopePluginTests.xcodeproj/UnitTests.xctestplan; sourceTree = "<group>"; };
+		9056A939285BDE4E0086CDF8 /* DeviceTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = DeviceTests.xctestplan; path = AppScopePluginTests.xcodeproj/DeviceTests.xctestplan; sourceTree = "<group>"; };
+		907328F228D04C0C006F6BFA /* www */ = {isa = PBXFileReference; lastKnownFileType = folder; name = www; path = ../../www; sourceTree = "<group>"; };
+		90B113082FCFAA4F007754D6 /* AppDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateTests.swift; sourceTree = "<group>"; };
+		90B1130A2FCFAEE9007754D6 /* SceneDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegateTests.swift; sourceTree = "<group>"; };
+		90B9E4E72FD1FA2900E708ED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		90D1FCC12FD1F223000192AF /* AppScopePluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppScopePluginTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		905131B627F1631300AC00FC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				905131EE27F1648A00AC00FC /* Cordova in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131CC27F1631600AC00FC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131D627F1631600AC00FC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		905131B027F1631300AC00FC = {
+			isa = PBXGroup;
+			children = (
+				9056A939285BDE4E0086CDF8 /* DeviceTests.xctestplan */,
+				9056A938285BDDC00086CDF8 /* UnitTests.xctestplan */,
+				905131BB27F1631300AC00FC /* App */,
+				905131D227F1631600AC00FC /* Tests */,
+				905131DC27F1631600AC00FC /* UITests */,
+				905131BA27F1631300AC00FC /* Products */,
+				909D55A627F176880050F168 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		905131BA27F1631300AC00FC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				905131B927F1631300AC00FC /* AppScopePluginTest.app */,
+				905131CF27F1631600AC00FC /* Tests.xctest */,
+				905131D927F1631600AC00FC /* UITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		905131BB27F1631300AC00FC /* App */ = {
+			isa = PBXGroup;
+			children = (
+				90B9E4E72FD1FA2900E708ED /* Info.plist */,
+				9053AFA42FCFA05100040EA5 /* CDVAppDelegate+AppScope.h */,
+				9053AFA52FCFA05100040EA5 /* CDVAppDelegate+AppScope.m */,
+				907328F228D04C0C006F6BFA /* www */,
+				905131F727F168FC00AC00FC /* AppScopePlugin.swift */,
+				905131F027F1670900AC00FC /* config.xml */,
+				905131BC27F1631300AC00FC /* AppDelegate.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		905131D227F1631600AC00FC /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				90D1FCC12FD1F223000192AF /* AppScopePluginTests.swift */,
+				90B1130A2FCFAEE9007754D6 /* SceneDelegateTests.swift */,
+				90B113082FCFAA4F007754D6 /* AppDelegateTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		905131DC27F1631600AC00FC /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = UITests;
+			sourceTree = "<group>";
+		};
+		909D55A627F176880050F168 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		905131B827F1631300AC00FC /* AppScopePluginTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 905131E327F1631600AC00FC /* Build configuration list for PBXNativeTarget "AppScopePluginTest" */;
+			buildPhases = (
+				905131B527F1631300AC00FC /* Sources */,
+				905131B627F1631300AC00FC /* Frameworks */,
+				905131B727F1631300AC00FC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AppScopePluginTest;
+			packageProductDependencies = (
+				905131ED27F1648A00AC00FC /* Cordova */,
+			);
+			productName = Tests;
+			productReference = 905131B927F1631300AC00FC /* AppScopePluginTest.app */;
+			productType = "com.apple.product-type.application";
+		};
+		905131CE27F1631600AC00FC /* Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 905131E627F1631600AC00FC /* Build configuration list for PBXNativeTarget "Tests" */;
+			buildPhases = (
+				905131CB27F1631600AC00FC /* Sources */,
+				905131CC27F1631600AC00FC /* Frameworks */,
+				905131CD27F1631600AC00FC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				905131D127F1631600AC00FC /* PBXTargetDependency */,
+			);
+			name = Tests;
+			packageProductDependencies = (
+			);
+			productName = TestsTests;
+			productReference = 905131CF27F1631600AC00FC /* Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		905131D827F1631600AC00FC /* UITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 905131E927F1631600AC00FC /* Build configuration list for PBXNativeTarget "UITests" */;
+			buildPhases = (
+				905131D527F1631600AC00FC /* Sources */,
+				905131D627F1631600AC00FC /* Frameworks */,
+				905131D727F1631600AC00FC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				905131DB27F1631600AC00FC /* PBXTargetDependency */,
+			);
+			name = UITests;
+			productName = TestsUITests;
+			productReference = 905131D927F1631600AC00FC /* UITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		905131B127F1631300AC00FC /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1330;
+				LastUpgradeCheck = 2630;
+				TargetAttributes = {
+					905131B827F1631300AC00FC = {
+						CreatedOnToolsVersion = 13.3;
+						LastSwiftMigration = 2630;
+					};
+					905131CE27F1631600AC00FC = {
+						CreatedOnToolsVersion = 13.3;
+						TestTargetID = 905131B827F1631300AC00FC;
+					};
+					905131D827F1631600AC00FC = {
+						CreatedOnToolsVersion = 13.3;
+						TestTargetID = 905131B827F1631300AC00FC;
+					};
+				};
+			};
+			buildConfigurationList = 905131B427F1631300AC00FC /* Build configuration list for PBXProject "AppScopePluginTests" */;
+			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 905131B027F1631300AC00FC;
+			packageReferences = (
+				905131EC27F1648A00AC00FC /* XCRemoteSwiftPackageReference "cordova-ios" */,
+			);
+			productRefGroup = 905131BA27F1631300AC00FC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				905131B827F1631300AC00FC /* AppScopePluginTest */,
+				905131CE27F1631600AC00FC /* Tests */,
+				905131D827F1631600AC00FC /* UITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		905131B727F1631300AC00FC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				907328F328D04C0C006F6BFA /* www in Resources */,
+				905131F127F1670900AC00FC /* config.xml in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131CD27F1631600AC00FC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131D727F1631600AC00FC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		905131B527F1631300AC00FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				905131F827F168FC00AC00FC /* AppScopePlugin.swift in Sources */,
+				9053AFA62FCFA05100040EA5 /* CDVAppDelegate+AppScope.m in Sources */,
+				905131BD27F1631300AC00FC /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131CB27F1631600AC00FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				90B113092FCFAA55007754D6 /* AppDelegateTests.swift in Sources */,
+				90B1130B2FCFAEED007754D6 /* SceneDelegateTests.swift in Sources */,
+				90D1FCC22FD1F227000192AF /* AppScopePluginTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		905131D527F1631600AC00FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		905131D127F1631600AC00FC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 905131B827F1631300AC00FC /* AppScopePluginTest */;
+			targetProxy = 905131D027F1631600AC00FC /* PBXContainerItemProxy */;
+		};
+		905131DB27F1631600AC00FC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 905131B827F1631300AC00FC /* AppScopePluginTest */;
+			targetProxy = 905131DA27F1631600AC00FC /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		905131E127F1631600AC00FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		905131E227F1631600AC00FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		905131E427F1631600AC00FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = App/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.appscope.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		905131E527F1631600AC00FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = App/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.appscope.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		905131E727F1631600AC00FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.appscope.tests.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AppScopePluginTest.app/AppScopePluginTest";
+			};
+			name = Debug;
+		};
+		905131E827F1631600AC00FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.appscope.tests.Tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AppScopePluginTest.app/AppScopePluginTest";
+			};
+			name = Release;
+		};
+		905131EA27F1631600AC00FC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"$(LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_$(SHALLOW_BUNDLE))",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.appscope.tests.UITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = AppScopePluginTest;
+			};
+			name = Debug;
+		};
+		905131EB27F1631600AC00FC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"$(LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_$(SHALLOW_BUNDLE))",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ayogo.cordova.appscope.tests.UITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = AppScopePluginTest;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		905131B427F1631300AC00FC /* Build configuration list for PBXProject "AppScopePluginTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				905131E127F1631600AC00FC /* Debug */,
+				905131E227F1631600AC00FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		905131E327F1631600AC00FC /* Build configuration list for PBXNativeTarget "AppScopePluginTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				905131E427F1631600AC00FC /* Debug */,
+				905131E527F1631600AC00FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		905131E627F1631600AC00FC /* Build configuration list for PBXNativeTarget "Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				905131E727F1631600AC00FC /* Debug */,
+				905131E827F1631600AC00FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		905131E927F1631600AC00FC /* Build configuration list for PBXNativeTarget "UITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				905131EA27F1631600AC00FC /* Debug */,
+				905131EB27F1631600AC00FC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		905131EC27F1648A00AC00FC /* XCRemoteSwiftPackageReference "cordova-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apache/cordova-ios.git";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		905131ED27F1648A00AC00FC /* Cordova */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 905131EC27F1648A00AC00FC /* XCRemoteSwiftPackageReference "cordova-ios" */;
+			productName = Cordova;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 905131B127F1631300AC00FC /* Project object */;
+}

--- a/tests/ios/AppScopePluginTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/tests/ios/AppScopePluginTests.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/tests/ios/AppScopePluginTests.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tests/ios/AppScopePluginTests.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/ios/AppScopePluginTests.xcodeproj/xcshareddata/xcschemes/AppScopePluginTests.xcscheme
+++ b/tests/ios/AppScopePluginTests.xcodeproj/xcshareddata/xcschemes/AppScopePluginTests.xcscheme
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "905131B827F1631300AC00FC"
+               BuildableName = "AppScopePluginTest.app"
+               BlueprintName = "AppScopePluginTest"
+               ReferencedContainer = "container:AppScopePluginTests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:AppScopePluginTests.xcodeproj/UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:AppScopePluginTests.xcodeproj/DeviceTests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "905131CE27F1631600AC00FC"
+               BuildableName = "Tests.xctest"
+               BlueprintName = "Tests"
+               ReferencedContainer = "container:AppScopePluginTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "905131D827F1631600AC00FC"
+               BuildableName = "UITests.xctest"
+               BlueprintName = "UITests"
+               ReferencedContainer = "container:AppScopePluginTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "905131B827F1631300AC00FC"
+            BuildableName = "AppScopePluginTest.app"
+            BlueprintName = "AppScopePluginTest"
+            ReferencedContainer = "container:AppScopePluginTests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "905131B827F1631300AC00FC"
+            BuildableName = "AppScopePluginTest.app"
+            BlueprintName = "AppScopePluginTest"
+            ReferencedContainer = "container:AppScopePluginTests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/tests/ios/Tests/AppDelegateTests.swift
+++ b/tests/ios/Tests/AppDelegateTests.swift
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2026 Darryl Pogue
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+import WebKit
+@testable import Cordova
+@testable import AppScopePluginTest
+
+class AppDelegateTests: XCTestCase {
+    var appDelegate: AppDelegate!
+
+    override func setUpWithError() throws {
+        self.appDelegate = (UIApplication.shared.delegate as! AppDelegate)
+    }
+
+    override func tearDownWithError() throws {
+        self.appDelegate = nil
+    }
+
+    func testContinueUserActivity() throws {
+        let url = URL(string: "http://example.com/index.html")
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = url
+
+        expectation(forNotification: NSNotification.Name.CDVPluginContinueUserActivity, object: activity, handler: nil)
+        expectation(forNotification: NSNotification.Name.CDVPluginHandleOpenURL, object: url, handler: nil)
+
+        self.appDelegate.application(UIApplication.shared, continue:activity, restorationHandler:{ (restorableObjects: [any UIUserActivityRestoring]?) in
+            return
+        })
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testContinueUserActivitySkipsNonWebpages() throws {
+        let activity = NSUserActivity(activityType: "SomethingElse")
+
+        expectation(forNotification: NSNotification.Name.CDVPluginContinueUserActivity, object: activity, handler: nil)
+        expectation(forNotification: NSNotification.Name.CDVPluginHandleOpenURL, object: nil, handler: nil).isInverted = true
+
+        self.appDelegate.application(UIApplication.shared, continue:activity, restorationHandler:{ (restorableObjects: [any UIUserActivityRestoring]?) in
+            return
+        })
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+}

--- a/tests/ios/Tests/AppScopePluginTests.swift
+++ b/tests/ios/Tests/AppScopePluginTests.swift
@@ -1,0 +1,199 @@
+/**
+ * Copyright 2026 Darryl Pogue
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+import WebKit
+@testable import Cordova
+@testable import AppScopePluginTest
+
+class MockWebViewEngine : NSObject, CDVWebViewEngineProtocol {
+    var engineWebView: UIView
+    var _loadedURL: URL?
+    var didReceiveLoadRequest: Bool = false
+
+    func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any, Error) -> Void)? = nil) { }
+
+    func url() -> URL {
+        return self._loadedURL ?? URL(string: "app://localhost")!
+    }
+
+    func canLoad(_ request: URLRequest) -> Bool {
+        return true
+    }
+
+    override init() {
+        self.engineWebView = WKWebView()
+    }
+
+    required init?(frame: CGRect) {
+        self.engineWebView = WKWebView()
+    }
+    required init?(frame: CGRect, configuration: WKWebViewConfiguration?) {
+        self.engineWebView = WKWebView()
+    }
+    func update(withInfo info: [AnyHashable : Any]) { }
+
+    func load(_ request: URLRequest) -> Any {
+        self._loadedURL = request.url
+        return self.didReceiveLoadRequest = true
+    }
+
+    func loadHTMLString(_ string: String, baseURL: URL?) -> Any { return 0 }
+}
+
+class AppScopePluginTests: XCTestCase {
+    var viewController: CDVViewController!
+    var plugin: AppScopePlugin!
+
+    override func setUpWithError() throws {
+        let appDelegate = (UIApplication.shared.delegate as! AppDelegate)
+        let window = appDelegate.window!
+
+        self.viewController = (window.rootViewController as! CDVViewController)
+        self.plugin = (self.viewController.getCommandInstance("AppScope") as! AppScopePlugin)
+    }
+
+    override func tearDownWithError() throws {
+        self.plugin.commandDelegate.settings.perform(#selector(NSMutableDictionary.removeObject(forKey:)), with:"scope")
+        self.plugin.setValue(self.viewController.webViewEngine, forKey:"webViewEngine")
+
+        self.plugin = nil
+        self.viewController = nil
+    }
+
+    // MARK: _handleOpenURL
+    func testHandleOpenURLWithoutURL() throws {
+        let mockWebViewEngine = MockWebViewEngine()
+        self.plugin.setValue(mockWebViewEngine, forKey:"webViewEngine")
+
+        NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: nil)
+
+        XCTAssertFalse(mockWebViewEngine.didReceiveLoadRequest)
+    }
+
+    func testHandleOpenURLWithoutDefinedScope() throws {
+        let mockWebViewEngine = MockWebViewEngine()
+        self.plugin.setValue(mockWebViewEngine, forKey:"webViewEngine")
+
+        NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: URL(string: "http://cordova.example.com/test.html"))
+
+        XCTAssertFalse(mockWebViewEngine.didReceiveLoadRequest)
+    }
+
+    func testHandleOpenURLWithNonMatchingScope() throws {
+        let mockWebViewEngine = MockWebViewEngine()
+        self.plugin.setValue(mockWebViewEngine, forKey:"webViewEngine")
+
+        self.plugin.commandDelegate.settings.setCordovaSetting("http://example.com/", forKey:"scope")
+
+        NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: URL(string: "http://cordova.example.com/test.html"))
+
+        XCTAssertFalse(mockWebViewEngine.didReceiveLoadRequest)
+    }
+
+    func testHandleOpenURLWithMatchingScope() throws {
+        let mockWebViewEngine = MockWebViewEngine()
+        self.plugin.setValue(mockWebViewEngine, forKey:"webViewEngine")
+
+        self.plugin.commandDelegate.settings.setCordovaSetting("http://cordova.example.com/", forKey:"scope")
+
+        NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: URL(string: "http://cordova.example.com/test.html"))
+
+        XCTAssertTrue(mockWebViewEngine.didReceiveLoadRequest)
+        XCTAssertTrue(mockWebViewEngine.url().absoluteString.hasPrefix("file:///"))
+        XCTAssertTrue(mockWebViewEngine.url().absoluteString.hasSuffix("/test.html"))
+    }
+
+    func testHandleOpenURLWithNoResourcePath() throws {
+        let mockWebViewEngine = MockWebViewEngine()
+        self.plugin.setValue(mockWebViewEngine, forKey:"webViewEngine")
+
+        self.plugin.commandDelegate.settings.setCordovaSetting("http://cordova.example.com/", forKey:"scope")
+
+        NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: URL(string: "http://cordova.example.com/"))
+
+        XCTAssertTrue(mockWebViewEngine.didReceiveLoadRequest)
+        XCTAssertTrue(mockWebViewEngine.url().absoluteString.hasPrefix("file:///"))
+        XCTAssertTrue(mockWebViewEngine.url().absoluteString.hasSuffix("/index.html"))
+    }
+
+    func testHandleOpenURLWithHash() throws {
+        let mockWebViewEngine = MockWebViewEngine()
+        self.plugin.setValue(mockWebViewEngine, forKey:"webViewEngine")
+
+        self.plugin.commandDelegate.settings.setCordovaSetting("http://cordova.example.com/", forKey:"scope")
+
+        NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: URL(string: "http://cordova.example.com/test.html#foo"))
+
+        XCTAssertTrue(mockWebViewEngine.didReceiveLoadRequest)
+        XCTAssertTrue(mockWebViewEngine.url().absoluteString.hasPrefix("file:///"))
+        XCTAssertTrue(mockWebViewEngine.url().absoluteString.hasSuffix("/test.html#foo"))
+    }
+
+    func testHandleOpenURLWithQueryParams() throws {
+        let mockWebViewEngine = MockWebViewEngine()
+        self.plugin.setValue(mockWebViewEngine, forKey:"webViewEngine")
+
+        self.plugin.commandDelegate.settings.setCordovaSetting("http://cordova.example.com/", forKey:"scope")
+
+        NotificationCenter.default.post(name: NSNotification.Name.CDVPluginHandleOpenURL, object: URL(string: "http://cordova.example.com/test.html?foo=bar"))
+
+        XCTAssertTrue(mockWebViewEngine.didReceiveLoadRequest)
+        XCTAssertTrue(mockWebViewEngine.url().absoluteString.hasPrefix("file:///"))
+        XCTAssertTrue(mockWebViewEngine.url().absoluteString.hasSuffix("/test.html?foo=bar"))
+    }
+
+    // MARK: _handleContinueUserActivity
+    func testContinueUserActivityWithoutActivity() throws {
+        expectation(forNotification: NSNotification.Name.CDVPluginHandleOpenURL, object: nil, handler: nil).isInverted = true
+
+        NotificationCenter.default.post(name: NSNotification.Name.CDVPluginContinueUserActivity, object: nil)
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testContinueUserActivityWithoutTypeBrowsingWeb() throws {
+        let activity = NSUserActivity(activityType: "SomethingElse")
+
+        expectation(forNotification: NSNotification.Name.CDVPluginHandleOpenURL, object: nil, handler: nil).isInverted = true
+
+        NotificationCenter.default.post(name: NSNotification.Name.CDVPluginContinueUserActivity, object: activity)
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testContinueUserActivityWithoutWebPage() throws {
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+
+        expectation(forNotification: NSNotification.Name.CDVPluginHandleOpenURL, object: nil, handler: nil).isInverted = true
+
+        NotificationCenter.default.post(name: NSNotification.Name.CDVPluginContinueUserActivity, object: activity)
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testContinueUserActivity() throws {
+        let url = URL(string: "http://example.com/index.html")
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = url
+
+        expectation(forNotification: NSNotification.Name.CDVPluginHandleOpenURL, object: url, handler: nil)
+
+        NotificationCenter.default.post(name: NSNotification.Name.CDVPluginContinueUserActivity, object: activity)
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+}

--- a/tests/ios/Tests/SceneDelegateTests.swift
+++ b/tests/ios/Tests/SceneDelegateTests.swift
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2026 Darryl Pogue
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import XCTest
+import WebKit
+@testable import Cordova
+@testable import AppScopePluginTest
+
+@available(iOS 13.0, *)
+class SceneDelegateTests: XCTestCase {
+    var scene: UIScene!
+    var sceneDelegate: SceneDelegate!
+
+    override func setUpWithError() throws {
+        self.scene = UIApplication.shared.connectedScenes.first
+        self.sceneDelegate = (self.scene?.delegate as! SceneDelegate)
+    }
+
+    override func tearDownWithError() throws {
+        self.sceneDelegate = nil
+        self.scene = nil
+    }
+
+    func testContinueUserActivity() throws {
+        let url = URL(string: "http://example.com/index.html")
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = url
+
+        expectation(forNotification: NSNotification.Name.CDVPluginContinueUserActivity, object: activity, handler: nil)
+        expectation(forNotification: NSNotification.Name.CDVPluginHandleOpenURL, object: url, handler: nil)
+
+        self.sceneDelegate.scene(self.scene, continue:activity)
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testContinueUserActivitySkipsNonWebpages() throws {
+        let activity = NSUserActivity(activityType: "SomethingElse")
+
+        expectation(forNotification: NSNotification.Name.CDVPluginContinueUserActivity, object: activity, handler: nil)
+        expectation(forNotification: NSNotification.Name.CDVPluginHandleOpenURL, object: nil, handler: nil).isInverted = true
+
+        self.sceneDelegate.scene(self.scene, continue:activity)
+
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+}

--- a/tests/www/index.html
+++ b/tests/www/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <style>
+    body {
+      padding: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px) env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
+    }
+    </style>
+  </head>
+  <body>
+    <h1>Hello Cordova</h1>
+  </body>
+</html>

--- a/tests/www/test.html
+++ b/tests/www/test.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <style>
+    body {
+      padding: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px) env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
+    }
+    </style>
+  </head>
+  <body>
+    <h1>This is a test case</h1>
+  </body>
+</html>
+


### PR DESCRIPTION
Cordova iOS 8 moves to using UISceneDelegate instead of UIApplicationDelegate for managing many of the lifecycle hooks, including continuation of user activities (such as clicking deep links). To facilitate this, cordova-ios 8.1.0 introduced a new `CDVPluginContinueUserActivityNotification` that is fired automatically from CDVSceneDelegate.

Since that's now API, let's restructure the plugin code a bit to emit that notification from our CDVAppDelegate extension, and handle it properly if it comes from the CDVSceneDelegate.